### PR TITLE
simplified code and ES6

### DIFF
--- a/Super_preloaderPlus_one_New.user.js
+++ b/Super_preloaderPlus_one_New.user.js
@@ -4715,15 +4715,12 @@
       url: 'http://wedata.net/databases/AutoPagerize/items.json',
       ruleParser: function(responseText){
           return JSON.parse(responseText).filter(function(i) {
-              if (i.name === 'Generic Posts Rule')
-                  return false;
-              else
-                  return true;
-          }).map(function(i) {
-                  i.data.name = i.name;
-                  i.data.source = 'wedata.net';
-                  return i.data;
-                  });
+              return (!(i.name === 'Generic Posts Rule'));
+            }).map(function(i) {
+                i.data.name = i.name;
+                i.data.source = 'wedata.net';
+                return i.data;
+            });
       }
     }
   ];

--- a/Super_preloaderPlus_one_New.user.js
+++ b/Super_preloaderPlus_one_New.user.js
@@ -6804,7 +6804,6 @@
 
         const findCurSiteInfo = function () {
           const SIIAD = SITEINFO_D.autopager;
-          var Rurl;
           const ii = SITEINFO.length;
 
           if (isChineseUI()) {
@@ -6817,7 +6816,7 @@
 
           for (var i = 0; i < ii; i++) {
             const SII = SITEINFO[i];
-            Rurl = toRE(SII.url);
+            const Rurl = toRE(SII.url);
             if (Rurl.test(url)) {
               if (isChineseUI()) {
                   debug('找到当前站点规则:', SII);

--- a/Super_preloaderPlus_one_New.user.js
+++ b/Super_preloaderPlus_one_New.user.js
@@ -75,8 +75,8 @@
   ];
 
   function CheckIframe () {
-    for (var i = 0; i < ChangeIframeSites.length; i++) {
-      if (toRE(ChangeIframeSites[i]).test(window.location.href)) {
+    for (let c of ChangeIframeSites) {
+      if (toRE(c).test(window.location.href)) {
         try {
           return window.self !== window.top;
         } catch (e) {
@@ -99,8 +99,8 @@
     mutationParser: function (mutation, ncheck) {
       if (mutation.type == 'childList') {
         if (mutation.addedNodes) {
-          for (var i = 0; i < mutation.addedNodes.length; i++) {
-            if (mutation.addedNodes[i].className.indexOf('photo-view') != -1) {
+          for (let node of mutation.addedNodes) {
+            if (node.className.indexOf('photo-view') != -1) {
               ncheck = ncheck + 1;
               break;
             }
@@ -119,11 +119,11 @@
     const domloaded = function () { // 滚动到底部,针对,某些使用滚动事件加载图片的网站.
       var targetNode;
       var LLS;
-      for (var i = 0; i < LazyLoadSites.length; i++) {
-        if (toRE(LazyLoadSites[i].url).test(window.location.href)) {
+      for (let site of LazyLoadSites) {
+        if (toRE(site.url).test(window.location.href)) {
           // Select the node that will be observed for mutations
-          targetNode = getElementByXpath(LazyLoadSites[i].target, document, document);
-          LLS = LazyLoadSites[i];
+          targetNode = getElementByXpath(site.target, document, document);
+          LLS = site;
           break;
         }
       }
@@ -133,8 +133,8 @@
         // Callback function to execute when mutations are observed
         const callback = function (mutationsList, observer) {
           // console.log("First callback");
-          for (var i = 0; i < mutationsList.length; i++) {
-            num_node_check = LLS.mutationParser(mutationsList[i], num_node_check);
+          for (let item of mutationsList) {
+            num_node_check = LLS.mutationParser(item, num_node_check);
             //  console.log(num_node_check);
             if (num_node_check == LLS.node_check_time) {
               //    console.log("finish");
@@ -4733,27 +4733,25 @@
       // jsonFinish: a callback after jsonRules are updated
       // create promises
       const jsonRulePromises = [];
-      for (var i = 0; i < jsonRuleProvider.length; i++ ){
-        (function(iurl) {
+      for (let provider of jsonRuleProvider){
           jsonRulePromises.push(new Promise(function(resolve, reject){
             const req = {
               method: "GET",
-              url: jsonRuleProvider[iurl].url,
+              url: provider.url,
               onload: function(res) {
                 var rule;
-                if (_.isFunction(jsonRuleProvider[iurl].ruleParser)) {
-                  rule = jsonRuleProvider[iurl].ruleParser(res.responseText);
+                if (_.isFunction(provider.ruleParser)) {
+                  rule = provider.ruleParser(res.responseText);
                 } else {
                   rule = JSON.parse(res.responseText);
                 }
-                debug('Rules from' + jsonRuleProvider[iurl].name + ' is updated');
+                debug('Rules from' + provider.name + ' is updated');
                 resolve(rule);
               },
-              onerror: function(res) {console.log(jsonRuleProvider[iurl].url, 'error');}
+              onerror: function(res) {console.log(provider.url, 'error');}
             };
             GM.xmlHttpRequest(req);
           }));
-        })(i);
       }
       Promise.all(jsonRulePromises).then(
         function(jsons){
@@ -5878,7 +5876,7 @@
             debug('移除各种事件监听');
             floatWO.updateColor('Astop');
             const _remove = remove;
-            for (var i = 0, ii = _remove.length; i < ii; i++) {
+            for (var i = 0, ii = _remove.length; i < ii; i++) { // TODO: forEach()
               _remove[i]();
             }
 
@@ -6348,8 +6346,7 @@
 
             const fragment = document.createDocumentFragment();
             const pageElements = getAllElements(SSS.a_pageElement, false, doc, win);
-            const ii = pageElements.length;
-            if (ii <= 0) {
+            if (pageElements.length <= 0) {
               debug('获取下一页的主要内容失败', SSS.a_pageElement);
               removeL();
               return;
@@ -6373,9 +6370,8 @@
             }
 
             var i, pe_x, pe_x_nn;
-            for (i = 0; i < ii; i++) {
-              pe_x = pageElements[i];
-              pe_x_nn = pe_x.nodeName;
+            for (let page of pageElements) {
+              pe_x_nn = page.nodeName;
               if (pe_x_nn == 'BODY' || pe_x_nn == 'HTML' || pe_x_nn == 'SCRIPT') continue;
               fragment.appendChild(pe_x);
             }
@@ -6422,8 +6418,8 @@
                   colNodes = getAllElements('child::*[self::td or self::th]', pageElements[0]);
               }
               var colums = 0;
-              for (var x = 0, l = colNodes.length; x < l; x++) {
-                const col = colNodes[x].getAttribute('colspan');
+              for (let c of colNodes) {
+                const col = c.getAttribute('colspan');
                 colums += parseInt(col, 10) || 1;
               }
               const td = doc.createElement('td');
@@ -6452,8 +6448,7 @@
               setTimeout(function () {
                 const _imgs = imgs;
                 var i, ii, img;
-                for (i = 0, ii = _imgs.length; i < ii; i++) {
-                  img = _imgs[i];
+                for (let img of _imgs) {
                   const src = img.src;
                   img.src = src;
                 }
@@ -6461,6 +6456,7 @@
             }
 
             if (SSS.a_replaceE) {
+              // TODO: map()
               const oldE = getAllElements(SSS.a_replaceE);
               const oldE_lt = oldE.length;
               // alert(oldE_lt);
@@ -7014,7 +7010,7 @@
           if (savedValue) {
             SSS.savedValue = savedValue;
             var i, ii;
-            for (i = 0, ii = savedValue.length; i < ii; i++) {
+            for (let savedValue_x of savedValue) {
               const savedValue_x = savedValue[i];
               if (savedValue_x.Rurl == SSS.Rurl) {
                 for (var ix in savedValue_x) {
@@ -7088,8 +7084,8 @@
           } else if (type == 'function') {
             ret = selector(doc, win, _cplink);
           } else if (selector instanceof Array) {
-            for (var i = 0, l = selector.length; i < l; i++) {
-              ret = getElement(selector[i], contextNode, doc, win);
+            for (let s of selector) {
+              ret = getElement(s, contextNode, doc, win);
               if (ret) {
                 break;
               }
@@ -7169,9 +7165,8 @@
             debug('全文档链接数量:', alllinksl);
           }
 
-          for (i = 0; i < alllinksl; i++) {
+          for (let a of alllinks) {
             if (_nextlink && _prelink) break;
-            a = alllinks[i];
             if (!a) continue; // undefined跳过
             // links集合返回的本来就是包含href的a元素..所以不用检测
             // if(!a.hasAttribute("href"))continue;
@@ -7275,8 +7270,7 @@
             }
             if (!atext) {
               aimgs = a.getElementsByTagName('img');
-              for (j = 0, jj = aimgs.length; j < jj; j++) {
-                aimg_x = aimgs[j];
+              for (let aimg_x of aimgs) {
                 atext = aimg_x.alt || aimg_x.title;
                 if (atext) break;
               }
@@ -7315,7 +7309,7 @@
         }
 
         function parseKWRE () {
-          function modifyPageKey (name, pageKey, pageKeyLength) {
+          function modifyPageKey (name, pageKey) {
             function strMTE (str) {
               return (str.replace(/\\/g, '\\\\')
                 .replace(/\+/g, '\\+')
@@ -7361,16 +7355,13 @@
             // alert(slwords);
             rep = prefs.cases ? '' : 'i';
 
-            for (var i = 0; i < pageKeyLength; i++) {
-              pageKey[i] = new RegExp(plwords + strMTE(pageKey[i]) + slwords, rep);
-              // alert(pageKey[i]);
-            }
-            return pageKey;
+            const newPK = pageKey.map((pk) => RegExp(plwords + strMTE(pk) + slwords, rep));
+            return newPK;
           }
 
           // 转成正则.
-          prePageKey = modifyPageKey('previous', prePageKey, prePageKey.length);
-          nextPageKey = modifyPageKey('next', nextPageKey, nextPageKey.length);
+          prePageKey = modifyPageKey('previous', prePageKey);
+          nextPageKey = modifyPageKey('next', nextPageKey);
         }
       }
 
@@ -7445,9 +7436,7 @@
         }
 
         if (!realPageSiteMatch) { // 不满足以上条件，再根据地址特征来匹配
-          var sitePattern;
-          for (var i = 0, length = REALPAGE_SITE_PATTERN.length; i < length; i++) {
-            sitePattern = REALPAGE_SITE_PATTERN[i];
+          for (let sitePattern of REALPAGE_SITE_PATTERN) {
             if (currentUrl.toLocaleLowerCase().indexOf(sitePattern) >= 0) {
               realPageSiteMatch = true;
               break;
@@ -7572,8 +7561,7 @@
         const array = [];
         var i, ii;
         var mValue;
-        for (i = 0, ii = mFails.length; i < ii; i++) {
-          fx = mFails[i];
+        for (let fx of mFails) {
           if (!fx) continue;
           if (typeof fx === 'string') {
             array.push(fx);
@@ -8015,21 +8003,11 @@
     }
 
     function unique (array) { // 数组去重并且保持数组顺序.
-      var i, ca, ca2, j;
-      for (i = 0; i < array.length; i++) {
-        ca = array[i];
-        for (j = i + 1; j < array.length; j++) {
-          ca2 = array[j];
-          if (ca2 == ca) {
-            array.splice(j, 1);
-            j--;
-          }
-        }
-      }
-      return array;
+      return Array.from(new Set(array));
     }
 
     function makeArray (x) {
+      // TODO: better
       var ret = [];
       var i, ii;
       var x_x;
@@ -8126,20 +8104,18 @@
     range.selectNodeContents(document.body);
     const fragment = range.createContextualFragment(str);
     doc.body.appendChild(fragment);
-    const headChildNames = {
-      TITLE: true,
-      META: true,
-      LINK: true,
-      STYLE: true,
-      BASE: true
-    };
-    var child;
-    const body = doc.body;
-    const bchilds = body.childNodes;
-    for (var i = bchilds.length - 1; i >= 0; i--) { // 移除head的子元素
-      child = bchilds[i];
-      if (headChildNames[child.nodeName]) body.removeChild(child);
-    }
+    const headChildRemoves = [
+      "TITLE",
+      "META",
+      "LINK",
+      "STYLE",
+      "BASE"
+    ]; // 要移除的子元素
+    // document.querySelectorAll('body>SCRIPT')
+    const bchilds = doc.body.childNodes;
+    bchilds.forEach((node) => {
+      if (headChildRemoves.includes(node.nodeName)) node.parentNode.removeChild(node);
+    }); // 移除head的子元素
     // alert(doc.documentElement.innerHTML);
     // debug(doc);
     // debug(doc.documentElement.innerHTML);

--- a/Super_preloaderPlus_one_New.user.js
+++ b/Super_preloaderPlus_one_New.user.js
@@ -7460,7 +7460,7 @@
           }
         }
 
-        var ralativePageStr;
+        let ralativePageStr = "";
         if (realPageSiteMatch) { // 如果匹配就显示实际网页信息
           if (isChineseUI()) {
             if (ralativePageNumarray[1] - ralativePageNumarray[0] > 1) { // 一般是搜索引擎的第xx - xx项……
@@ -7479,10 +7479,8 @@
               ralativePageStr = ' [ <font color="red">Actual elements ends</font> ]';
             }
           }
-        } else {
-          ralativePageStr = '';
         }
-        return ralativePageStr || '';
+        return ralativePageStr;
       }
     }
   );

--- a/Super_preloaderPlus_one_New.user.js
+++ b/Super_preloaderPlus_one_New.user.js
@@ -4894,6 +4894,10 @@
 
   // ------------------------下面的不要管他-----------------
   /// ////////////////////////////////////////////////////////////////
+  function isChineseUI() {
+    return (userLang.indexOf('zh') !== -1) || prefs.ChineseUI;
+  }
+
   Promise.all([
     GM.getValue('prefs', JSON.stringify(prefs)),
     GM.getValue('SITEINFO_D', JSON.stringify(SITEINFO_D)),
@@ -4955,7 +4959,7 @@
         var div = d.createElement('div');
         div.id = 'sp-prefs-setup';
         d.body.appendChild(div);
-        if ((userLang.indexOf('zh') !== -1) || prefs.ChineseUI) {
+        if (isChineseUI()) {
           div.innerHTML = '\
                            <div>Super_preloaderPlus_one_New设置</div>\
                                <ul>\
@@ -5080,7 +5084,7 @@
 
           this.loadSetting();
 
-          if ((userLang.indexOf('zh') !== -1) || prefs.ChineseUI) {
+          if (isChineseUI()) {
             GM.registerMenuCommand('Super_preloaderPlus_one_New 设置', setup);
           } else {
             GM.registerMenuCommand('Super_preloaderPlus_one_New', setup);
@@ -5560,7 +5564,7 @@
 
         function floatWindowUI () {
           var innerHTML = '';
-          if ((userLang.indexOf('zh') !== -1) || prefs.ChineseUI) {
+          if (isChineseUI()) {
             innerHTML = '\
                                 <div id="sp-fw-rect" style="background-color:#000;">\
                                     <div id="sp-fw-dot" style="display:none;"></div>\
@@ -6115,7 +6119,7 @@
               });
               manualDiv = div;
               var nextStr = 'Next';
-              if ((userLang.indexOf('zh') !== -1) || prefs.ChineseUI) {
+              if (isChineseUI()) {
                 nextStr = '下';
               }
               const span = $C('span', {
@@ -6156,7 +6160,7 @@
                 }
               }, false);
               div.appendChild(input);
-              if ((userLang.indexOf('zh') !== -1) || prefs.ChineseUI) {
+              if (isChineseUI()) {
                 div.appendChild($C('span', {
                   className: 'sp-sp-md-span'
                 }, '页'));
@@ -6263,7 +6267,7 @@
               div.id = 'sp-separator-' + curNumber;
               div.addEventListener('click', sepHandler, false);
               var pageStr = '';
-              if ((userLang.indexOf('zh') !== -1) || prefs.ChineseUI) {
+              if (isChineseUI()) {
                 pageStr = '第 <span style="color:red!important;">' + curNumber + '</span> 页' +
                                     (SSS.a_separatorReal ? getRalativePageStr(lastUrl, currentUrl, nextUrl) : '');
               } else {
@@ -6803,7 +6807,7 @@
           var Rurl;
           const ii = SITEINFO.length;
 
-          if ((userLang.indexOf('zh') !== -1) || prefs.ChineseUI) {
+          if (isChineseUI()) {
               debug('高级规则数目:',ii);
               debug('规则数 > ', ii - SITEINFO_json.length, '来自其他来源, 比如: wedata.net');
           } else {
@@ -6815,7 +6819,7 @@
             const SII = SITEINFO[i];
             Rurl = toRE(SII.url);
             if (Rurl.test(url)) {
-              if ((userLang.indexOf('zh') !== -1) || prefs.ChineseUI) {
+              if (isChineseUI()) {
                   debug('找到当前站点规则:', SII);
                   debug('规则ID: ', i + 1);
               } else {
@@ -7459,7 +7463,7 @@
 
         var ralativePageStr;
         if (realPageSiteMatch) { // 如果匹配就显示实际网页信息
-          if ((userLang.indexOf('zh') !== -1) || prefs.ChineseUI) {
+          if (isChineseUI()) {
             if (ralativePageNumarray[1] - ralativePageNumarray[0] > 1) { // 一般是搜索引擎的第xx - xx项……
               ralativePageStr = ' [ 实际：第 <font color="red">' + ralativePageNumarray[0] + ' - ' + ralativePageNumarray[1] + '</font> 项 ]';
             } else if ((ralativePageNumarray[1] - ralativePageNumarray[0]) === 1) { // 一般的翻页数，差值应该是1

--- a/Super_preloaderPlus_one_New.user.js
+++ b/Super_preloaderPlus_one_New.user.js
@@ -67,9 +67,7 @@
   // ----------------------------------
   // rule.js
 
-  if (window.name === 'mynovelreader-iframe') {
-    return;
-  }
+  if (window.name === 'mynovelreader-iframe') return;
 
   // Website which has script to change window name
   const ChangeIframeSites = [
@@ -86,7 +84,7 @@
         }
       }
     }
-    if (window.name === 'superpreloader-iframe') { return true; } else { return false; }
+    return window.name === 'superpreloader-iframe';
   }
 
   // Website which uses lazyload feature [url, xpath, timeout]


### PR DESCRIPTION
代码简化，提升可读性。只做了简单测试，所以可以测试一段时间再说。

修改的起因是想将`SITEINFO_json`改成不常驻内存的方式，如按需加载。不过，`GM.getValue`若不使用`async`（ES2017），好像不太好写成函数。
json源码约2MB字符串，每个标签页都会占用一份，而且加载终止没有做释放。不确定浏览器/操作系统对那些对象能做多大程度的内存合并与压缩，感觉它们占用了不少。

----
对代码的一些疑问/征询：
1. `.eslintrc.js`填了好多规则，是均有意设定，还是从别地摘来的。如果摘来的，我在考虑简化和修改。
2. 对使用[async](https://es6.ruanyifeng.com/#docs/async)（`"ecmaVersion": 8`，ES2017）的看法。如果提升了这个需求，是否必须配个`babel`来生成兼容版。
3. 如果用`async`，不少代码能从回调改成更有可读性的写法。虽然并不会有多少收益，并且改写会引入bug。
4. 接受功能请求吗，有几个想法，但没有多少动力去写/研究。例如允许'立即翻页'时超过100页限制，允许临时规则保存时设定路径匹配级别，乃至临时规则转json的规则生成器（只是想法）。