### PR TITLE
Exit early if current page is a file

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -63,6 +63,14 @@ import notice from './utils/notice';
   let SSRules = [];
   // ----------------------------------
 
+  if (
+    document.body.firstElementChild.tagName === 'PRE' || // Plain text
+    document.body.firstElementChild.tagName === 'IMG' || // Image
+    document.body.firstElementChild.tagName === 'EMBED' // PDF
+  ) {
+    return;
+  }
+  
   if (window.name === 'mynovelreader-iframe') {
     return;
   }

--- a/src/index.js
+++ b/src/index.js
@@ -66,6 +66,7 @@ import notice from './utils/notice';
   if (
     document.body.firstElementChild.tagName === 'PRE' || // Plain text
     document.body.firstElementChild.tagName === 'IMG' || // Image
+    document.body.firstElementChild.tagName === 'VIDEO' || // Audio and Video
     document.body.firstElementChild.tagName === 'EMBED' // PDF
   ) {
     return;


### PR DESCRIPTION
I don't know if there is a universal way to tell if the browser is looking at a file rather than a webpage, so this is just a dumb way to exclude the most common file types on Chromium. AFAIK this won't affect most of the websites.

An alternative way is to check if the title is empty, however this doesn't work for images and PDF.