### PR TITLE
Improve file detection logic

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -63,12 +63,16 @@ import notice from './utils/notice';
   let SSRules = [];
   // ----------------------------------
 
+  // Check if we are looking at a file instead of a webpage
   if (
-    BROWSER.name !== 'firefox' &&
-    (document.body.firstElementChild.tagName === 'PRE' || // Plain text
-      document.body.firstElementChild.tagName === 'IMG' || // Image
-      document.body.firstElementChild.tagName === 'VIDEO' || // Audio and Video
-      document.body.firstElementChild.tagName === 'EMBED') // PDF
+    // <svg>: SVG Document
+    document.documentElement.matches('svg') ||
+    // <pre>: plain text
+    // <img>: Image
+    // <video>: Audio and video
+    // <embed>: PDF (Chrome)
+    // body > #outerContainer:first-child + #printContainer:last-child: PDF (Firefox)
+    document.querySelector('body > pre:only-child, body > img:only-child, body > video:only-child, body > embed:only-child, body > #outerContainer:first-child + #printContainer:last-child')
   ) {
     return;
   }


### PR DESCRIPTION
This is like #415, but less verbose and has a few extra features.

- Also checks for `<svg>` document
- Check if `<body>` only has exactly one child, less false positives. The previous logic works fine though
- Support PDF.js (used by Firefox, among others), the selector looks scary but it works

I've checked that apart from PDF, Chromium and Firefox render the same type of content using similar DOM  structures, so there is no need to guard everything with `BROWSER.name !== 'firefox'`.

## Test URLs

Plain text: https://0x0.st/
Image (only-child): https://avatars.githubusercontent.com/u/583231?v=4
Image (not only-child): https://thispersondoesnotexist.com/
SVG: https://github.githubassets.com/images/modules/site/home/repo-editor-glow.svg
PDF: http://tkc.tw/bike/1-1.pdf
Audio: https://file-examples-com.github.io/uploads/2017/11/file_example_MP3_700KB.mp3
Video: https://github.githubassets.com/images/modules/site/home/actions-autocomplete.h264.mp4