### PR TITLE
Update jsGeneralRule.js

### DIFF
--- a/src/rules/jsGeneralRule.js
+++ b/src/rules/jsGeneralRule.js
@@ -268,7 +268,7 @@ export const jsGeneralRule = [
       if (a[2]) {
         const b = Number(/\/page\/(\d+)/.exec(a[2])[1]) + 1;
         return cplink.replace(/^(https?:\/\/.*?\/page\/)\d+(.*)$/, '$1' + String(b) + '$2');
-      } else if(window.wp){
+      } else if(_doc.documentElement.querySelector("link[href*='wp-includes']")){
         return cplink.replace(/^(.*?)\/?$/, '$1') + '/page/2';
       }
       return undefined;

--- a/src/rules/jsGeneralRule.js
+++ b/src/rules/jsGeneralRule.js
@@ -268,9 +268,10 @@ export const jsGeneralRule = [
       if (a[2]) {
         const b = Number(/\/page\/(\d+)/.exec(a[2])[1]) + 1;
         return cplink.replace(/^(https?:\/\/.*?\/page\/)\d+(.*)$/, '$1' + String(b) + '$2');
-      } else {
+      } else if(window.wp){
         return cplink.replace(/^(.*?)\/?$/, '$1') + '/page/2';
       }
+      return undefined;
     },
     autopager: {
       pageElement: function (doc, win, _cplink) {


### PR DESCRIPTION
Fix wordpress as `url: '^https?://[^/]+(/page/\\d+)?',` will effect in every site with the last regexp'?'. And when no rule was found, the `/page/2` will be added always