### PR TITLE
mydata: Added support for Google Basic Variant

### DIFF
--- a/dist/mydata.json
+++ b/dist/mydata.json
@@ -3694,5 +3694,12 @@
     "url": "^https?://bluemoonroleplaying\\.com/community/*",
     "pageElement": "//*[@class='block-container lbContainer']",
     "nextLink": "//li[contains(@class,'current')]/following-sibling::li[1]/a"
+  },
+  {
+    "name": "Google Basic Variant",
+    "url": "^https?://www\\.google\\.com/search\\?(?:[^/]+&)?gbv=1(?:$|[&/])",
+    "pageElement": "css;div#main",
+    "exampleUrl": "https://www.google.com/search?q=foo&gbv=1",
+    "nextLink": "//a[@aria-label=\"Next page\"]"
   }
 ]

--- a/dist/mydata.json
+++ b/dist/mydata.json
@@ -3697,7 +3697,7 @@
   },
   {
     "name": "Google Basic Variant",
-    "url": "^https?://www\\.google\\.com/search\\?(?:[^/]+&)?gbv=1(?:$|[&/])",
+    "url": "^https?://w{3}\\.google\\.(?:a[delmstz]|b[aefgijsty]|c(?:o(?:m(?:\\.(?:a[fgru]|b[dhnorz]|c[ouy]|do|e[cgt]|fj|g[hit]|hk|jm|k[hw]|l[by]|m[mtxy]|n[agip]|om|p[aeghkry]|qa|s[abglv]|t[jrw]|u[ay]|v[cn]))?|\\.(?:ao|bw|c[kr]|i[dln]|jp|k[er]|ls|m[az]|nz|t[hz]|u[gkz]|v[ei]|z[amw]))|[adfghilmnvz])|d[ejkmz]|e[es]|f[imr]|g[aeglmry]|h[nrtu]|i[emqst]|j[eo]|k[giz]|l[aiktuv]|m[degklnuvw]|n[eloru]|p[lnst]|r[osuw]|s[cehikmnort]|t[dglmnot]|vu|ws)/search\\?(?:[^/]+&)?gbv=1(?:$|[&/])",
     "pageElement": "css;div#main",
     "exampleUrl": "https://www.google.com/search?q=foo&gbv=1",
     "nextLink": "//a[@aria-label=\"Next page\"]"


### PR DESCRIPTION
While this query param doesn't actually work by itself, `script-src` has to be set to `none`. To be able to swap between the default and GBV mode, you can paste the line below into `My filters` in the uBlock Origin settings.
```
/^https?:\/{2}w{3}\.google\.(?:a[delmstz]|b[aefgijsty]|c(?:o(?:m(?:\.(?:a[fgru]|b[dhnorz]|c[ouy]|do|e[cgt]|fj|g[hit]|hk|jm|k[hw]|l[by]|m[mtxy]|n[agip]|om|p[aeghkry]|qa|s[abglv]|t[jrw]|u[ay]|v[cn]))?|\.(?:ao|bw|c[kr]|i[dln]|jp|k[er]|ls|m[az]|nz|t[hz]|u[gkz]|v[ei]|z[amw]))|[adfghilmnvz])|d[ejkmz]|e[es]|f[imr]|g[aeglmry]|h[nrtu]|i[emqst]|j[eo]|k[giz]|l[aiktuv]|m[degklnuvw]|n[eloru]|p[lnst]|r[osuw]|s[cehikmnort]|t[dglmnot]|vu|ws)\/search\?(?:[^/]+&)?gbv=1(?:$|[&/])/$csp=script-src 'none'
```
The site will actually redirect and strip off the `gbv` query param with `script-src` enabled, but with it set to `none`, the user can choose which mode they want to use, and the query param works as you'd expect. Both `1` (GBV) or `2` (Default Google) work (although sometimes you need to hard refresh cache when swapping back and forth <kbd>CTRL</kbd>+<kbd>F5</kbd>/<kbd>CTRL</kbd>+<kbd>SHIFT</kbd>+<kbd>R</kbd>), this at least gives a way to distinguish a user's intent.