### PR TITLE
ci: Fix deprecated version of `actions/upload-artifact`

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -33,7 +33,7 @@ jobs:
           pnpm run check
           pnpm run build
       - name: Artiface Archive
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@main
         with:
           name: Super_preloaderPlus_one_New.user.js
           path: dist/Super_preloaderPlus_one_New.user.js


### PR DESCRIPTION
>Error: This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v2`. Learn more: https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/

https://github.com/machsix/Super-preloader/actions/runs/14372294365/job/40297490123